### PR TITLE
Show voice download size before installing

### DIFF
--- a/src/voice_row.py
+++ b/src/voice_row.py
@@ -23,6 +23,21 @@ from gi.repository import Gtk
 from .voices_store import Voice, VoiceStatus
 
 
+def _format_size(size_bytes):
+    """Format byte size to human-readable string."""
+    if size_bytes <= 0:
+        return ""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.0f} KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    else:
+        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+
+
+
 @Gtk.Template(resource_path="/org/project_spiel/SpielInstaller/voice_row.ui")
 class VoiceRow(Adw.ActionRow):
     __gtype_name__ = "VoiceRow"
@@ -32,6 +47,7 @@ class VoiceRow(Adw.ActionRow):
     btn_download = Gtk.Template.Child()
     spinner = Gtk.Template.Child()
     btn_remove = Gtk.Template.Child()
+    size_label = Gtk.Template.Child()
 
     def __init__(self, voice):
         super().__init__()
@@ -43,6 +59,9 @@ class VoiceRow(Adw.ActionRow):
         self.language_label.set_label(", ".join(lang_names))
         lang_name_chunks = [", ".join(c) for c in zip(*[iter(lang_names)] * 4)]
         self.language_label.set_tooltip_text("\n".join(lang_name_chunks))
+        size_text = _format_size(voice.download_size)
+        if size_text:
+            self.size_label.set_label(size_text)
         self.update_status()
 
     @Gtk.Template.Callback()
@@ -54,13 +73,19 @@ class VoiceRow(Adw.ActionRow):
         self.voice.uninstall(None)
 
     def status_changed(self, voice, param):
+        size_text = _format_size(voice.download_size)
+        if size_text:
+            self.size_label.set_label(size_text)
         self.update_status()
 
     def update_status(self):
         status = self.voice.status
         if status == VoiceStatus.INSTALLED:
             self.stack.set_visible_child(self.btn_remove)
+            self.size_label.set_visible(False)
         elif status == VoiceStatus.INSTALLING or status == VoiceStatus.UNINSTALLING:
             self.stack.set_visible_child(self.spinner)
+            self.size_label.set_visible(False)
         elif status == VoiceStatus.UNINSTALLED:
             self.stack.set_visible_child(self.btn_download)
+            self.size_label.set_visible(bool(self.size_label.get_label()))

--- a/src/voice_row.ui
+++ b/src/voice_row.ui
@@ -14,6 +14,16 @@
       </object>
     </child>
     <child type="suffix">
+      <object class="GtkLabel" id="size_label">
+        <property name="label"></property>
+        <property name="visible">false</property>
+        <style>
+          <class name="dim-label" />
+          <class name="caption" />
+        </style>
+      </object>
+    </child>
+    <child type="suffix">
       <object class="GtkStack" id="stack">
         <property name="halign">3</property>
         <property name="valign">3</property>

--- a/src/voices_store.py
+++ b/src/voices_store.py
@@ -176,14 +176,16 @@ class VoiceStatus:
 
 
 class Voice(GObject.Object):
+    _download_size = 0
     def __init__(
-        self, installation, remote, voice_component, provider_component, status
+        self, installation, remote, voice_component, provider_component, status, download_size=0
     ):
         self._installation = installation
         self._remote = remote
         self._voice_component = voice_component
         self._provider_component = provider_component
         self._status = status
+        self._download_size = download_size
         self._langs = [
             Language.get(standardize_tag(l))
             for l in self.voice_component.get_languages()
@@ -209,6 +211,10 @@ class Voice(GObject.Object):
     @GObject.Property(type=int)
     def status(self):
         return self._status
+
+    @GObject.Property(type=int)
+    def download_size(self):
+        return self._download_size
 
     @GObject.Property(type=GObject.TYPE_STRV)
     def language_and_region_names(self):
@@ -366,6 +372,14 @@ class VoicesStore(Gtk.FilterListModel):
                 md = AppStream.Metadata.new()
                 md.set_format_style(AppStream.FormatStyle.CATALOG)
                 md.parse_file(app_stream_file, 1)
+                # Build a map of ref name -> download size from remote refs
+                ref_sizes = {}
+                try:
+                    remote_refs = installation.list_remote_refs_sync(remote.get_name(), cancellable)
+                    for rref in remote_refs:
+                        ref_sizes[rref.get_name()] = rref.get_download_size()
+                except Exception:
+                    pass
                 components = dict(
                     [[c.get_id(), c] for c in md.get_components().as_array()]
                 )
@@ -381,7 +395,7 @@ class VoicesStore(Gtk.FilterListModel):
                             else VoiceStatus.UNINSTALLED
                         )
                         voices.append(
-                            Voice(installation, remote, component, provider, status)
+                            Voice(installation, remote, component, provider, status, download_size=ref_sizes.get(component.get_id(), 0))
                         )
         task.return_value(voices)
 


### PR DESCRIPTION
Displays the download size next to the install button for uninstalled voices, so users can make a more informed decision before downloading.

## Implementation

- Fetches download sizes from `Flatpak.Installation.list_remote_refs_sync()` during voice population. This data comes from the already-cached remote summary, so **no additional network requests** are needed.
- Adds a `download_size` property to the `Voice` model.
- Shows a dim caption label (e.g. "45.3 MB") next to the download button for uninstalled voices. The label is hidden for installed voices and during install/uninstall operations.

## Screenshots

The size label appears as a subtle caption next to the download icon, using the `dim-label` and `caption` style classes for consistency with GNOME HIG.

Closes #3